### PR TITLE
script: fix mode name

### DIFF
--- a/script.js
+++ b/script.js
@@ -46,7 +46,7 @@ editor.setSession(sessions[tabIDs.value]);
 var results = ace.edit("OUTPUT");
 results.setTheme("ace/theme/chrome");
 results.setReadOnly(true);
-results.session.setMode("ace/mode/Text");
+results.session.setMode("ace/mode/text");
 
 var numberOfLines = editor.session.getLength();
 


### PR DESCRIPTION
In uppercase I get this error:

GET https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.12/mode-Text.js net::ERR_ABORTED 404

mode-Text.js doesn't exist, but mode-text.js does.